### PR TITLE
Use exfiltrated json decoder to get at private details

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "ExfiltratedJSONDecoder",
+        "repositoryURL": "https://github.com/GeorgeLyon/ExfiltratedJSONDecoder.git",
+        "state": {
+          "branch": "main",
+          "revision": "a3accd4caae31c6b9c951713f6a02f61092b4e66",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,7 @@ let package = Package(
             targets: ["UsefulDecode"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/GeorgeLyon/ExfiltratedJSONDecoder.git", .branch("main"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -29,6 +28,9 @@ let package = Package(
             dependencies: []),
         .testTarget(
             name: "UsefulDecodeTests",
-            dependencies: ["UsefulDecode"]),
+            dependencies: [
+                "UsefulDecode",
+                "ExfiltratedJSONDecoder",
+            ]),
     ]
 )

--- a/Tests/UsefulDecodeTests/UsefulDecodeTests.swift
+++ b/Tests/UsefulDecodeTests/UsefulDecodeTests.swift
@@ -7,11 +7,12 @@
 
 import XCTest
 @testable import UsefulDecode
+import ExfiltratedJSONDecoder
 
 class UsefulDecodeTests: XCTestCase {
 
-    let decoder: JSONDecoder = {
-        let d = JSONDecoder()
+    let decoder: Foundation.JSONDecoder = {
+        let d = Foundation.JSONDecoder()
         d.keyDecodingStrategy = .convertFromSnakeCase
         return d
     }()
@@ -164,6 +165,20 @@ class UsefulDecodeTests: XCTestCase {
             """)
         // TODO: Support multiple key decoding strategies?
         XCTExpectFailure("NOTE: this test is known to fail because the type that we get from the error is KeyedDecodingContainer<CodingKeys> or something like that instead of Address, which is what we would expect. Probably a JSONDecoder bug? But may be intentional? Unclear.")
+
+        let exf: ExfiltratedJSONDecoder.JSONDecoder = {
+            let d = ExfiltratedJSONDecoder.JSONDecoder()
+            d.keyDecodingStrategy = .convertFromSnakeCase
+            return d
+        }()
+        do {
+            _ = try exf.decode([Person].self, from: data)
+        }
+        catch {
+            var s = ""
+            dump(error, to: &s)
+            print(s)
+        }
         XCTAssertThrowsError(try decoder.decodeWithBetterErrors([Person].self, from: data)) { error in
             XCTAssertEqual(String(describing: error), """
                 Value not found: expected 'address' (Address) at [0]/address, got:


### PR DESCRIPTION
Provides for better error messages in some cases. Work-in-progress.

Discussion: https://forums.swift.org/t/how-to-build-and-debug-jsondecoder/44690