### PR TITLE
Handle issues when decoding keys at the top level of an object

### DIFF
--- a/Sources/UsefulDecode/Decoding.swift
+++ b/Sources/UsefulDecode/Decoding.swift
@@ -8,14 +8,17 @@
 import Foundation
 
 func processDecodingError(_ error: DecodingError, inJSONObject jsonObject: Any) -> Error {
-    guard let context = error.context else {
+  guard let context = error.context else {
         return NoContextError(underlying: error)
     }
+  guard let key = context.codingPath.first else {
+    return BetterNoValueFound(debugDescription: context.debugDescription, container: jsonObject)
+  }
     return processDecodingErrorRecursive(
         error,
         context: context,
         inJSONObject: jsonObject,
-        key: context.codingPath.first!,
+        key: key,
         remainingCodingPath: context.codingPath.dropFirst()
     )
 }

--- a/Sources/UsefulDecode/Errors.swift
+++ b/Sources/UsefulDecode/Errors.swift
@@ -59,6 +59,11 @@ public struct BetterValueNotFound: Error {
     let path: [CodingKey]
 }
 
+public struct BetterNoValueFound: Error {
+  let debugDescription: String
+  let container: Any
+}
+
 public struct DataCorrupted: Error {
     let path: [CodingKey]
 }
@@ -83,6 +88,12 @@ private func objectToJSON(_ object: Any) -> String {
         return String(describing: object)
     }
 
+}
+
+extension BetterNoValueFound: CustomStringConvertible {
+  public var description: String {
+      "Value not found: \(debugDescription), got:\n\(objectToJSON(container))"
+  }
 }
 
 extension BetterTypeMismatch: CustomStringConvertible {

--- a/Tests/UsefulDecodeTests/UsefulDecodeTests.swift
+++ b/Tests/UsefulDecodeTests/UsefulDecodeTests.swift
@@ -194,6 +194,26 @@ class UsefulDecodeTests: XCTestCase {
         }
     }
 
+  func testFirstLevelCrash() throws {
+    // Should crash because "name" is spelled "names"
+    let data = makeData("""
+{
+      "names": "Big",
+      "feathers": "some"
+}
+  
+""")
+    
+    XCTAssertThrowsError(try decoder.decodeWithBetterErrors(Bird.self, from: data)) { error in
+      XCTAssertEqual(String(describing: error), """
+Value not found: No value associated with key CodingKeys(stringValue: "name", intValue: nil) ("name")., got:
+{
+  "feathers" : "some",
+  "names" : "Big"
+}
+""")
+    }
+  }
 
 }
 


### PR DESCRIPTION
Add a fix to handle issues when decoding keys at the top level of an object